### PR TITLE
Link in the database.yml file

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -17,7 +17,8 @@ set :ssh_options,
     auth_methods: %w(publickey)
 
 set :linked_files,
-    fetch(:linked_files, []).push('config/initializers/environment_variables.rb')
+    fetch(:linked_files, []).push('config/initializers/environment_variables.rb',
+                                  'config/database.yml')
 
 set :linked_dirs,
     fetch(:linked_dirs, []).push('log',


### PR DESCRIPTION
We need to use the database.yml file that is in the shared directory, not the one that has been checked into the repo.  Ansible is placing a copy of the database.yml file into the shared directory - use the file in the shared directory since it has the necessary credentials to access staging and production databases. 

The credentials had been in the `config/initializers/environment_variables.rb` file, but some rake tasks (such as `rake db:seed`) were unable to correctly access the ENV variables, causing the task to throw an error because it was unable to connect to the DB.  This appears to be a bug in rake. The simple work around was to stop using ENV variables and directly store the values in the database.yml file, which is what we usually do for our project.

We had considered placing the ENV variables in a bashrc file, but decided against this route due to security concerns.
