### PR TITLE
Link the db/json/building.json on deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -18,7 +18,8 @@ set :ssh_options,
 
 set :linked_files,
     fetch(:linked_files, []).push('config/initializers/environment_variables.rb',
-                                  'config/database.yml')
+                                  'config/database.yml',
+                                  'db/json/buildings.json')
 
 set :linked_dirs,
     fetch(:linked_dirs, []).push('log',


### PR DESCRIPTION
Need to link in the db/json/building.json file that is stored in the
shared directory. This file is needed for the db:seed rake task.
